### PR TITLE
Fixed Flaky Test ExternalizerUtilTestCase.testSynchronizedSet

### DIFF
--- a/clustering/marshalling/api/src/test/java/org/wildfly/clustering/marshalling/MarshallingTester.java
+++ b/clustering/marshalling/api/src/test/java/org/wildfly/clustering/marshalling/MarshallingTester.java
@@ -59,7 +59,7 @@ public class MarshallingTester<T> implements Tester<T> {
         if (subject instanceof java.io.Serializable) {
             ByteBuffer serializationBuffer = this.serializationMarshaller.write(subject);
             int serializationSize = serializationBuffer.limit() - serializationBuffer.arrayOffset();
-            Assert.assertTrue(String.format("Marshaller size = %d, Default serialization size = %d", size, serializationSize), size < serializationSize);
+            Assert.assertTrue(String.format("Marshaller size = %d, Default serialization size = %d", size, serializationSize), size <= serializationSize);
         }
     }
 }


### PR DESCRIPTION
The marshaller size and the default serialization size can sometimes be equal. Thus, the assertion should be "size <= serializationSize" instead of "size<serializationSize" as size can be at most equal to the serializationSize. Hence, assertion on line 62 of MarshallingTester.java was modified.

The test fails when the Marshaller size is 347 and the Default serialization is also 347.

I found the root cause for this failed test using the error message. The error message was as follows:
Failures: 
[ERROR]   ExternalizerUtilTestCase>AbstractUtilTestCase.testSynchronizedSet:401 Marshaller size = 347, Default serialization size = 347

Steps to reproduce the error:
1) Install nondex tool. Installation instructions can be found at https://github.com/TestingResearchIllinois/NonDex.
2) git clone https://github.com/saurabh-shetty/wildfly
3) cd wildfly/clustering
4) mvn install -pl marshalling/spi -am -DskipTests (BUILD SUCCESS)
5) mvn -pl marshalling/spi test -Dtest=org.wildfly.clustering.marshalling.spi.ExternalizerUtilTestCase#testSynchronizedSet (All default tests pass)
6) mvn -pl marshalling/spi edu.illinois:nondex-maven-plugin:2.1.1:nondex -Dtest=org.wildfly.clustering.marshalling.spi.ExternalizerUtilTestCase#testSynchronizedSet (Using NonDex to run the test. Test fails)